### PR TITLE
Add link to GitHub page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 - VS Code
 - Git, GitHub
 
+## Link to website
+
+[George M'sapenda Portifolio](https://c00p75.github.io/Portfolio-setup-and-mobile-first/)
+
 ## Authors
 
 👤 **Author1**


### PR DESCRIPTION
- Deployed website using GitHub Pages.
- Ensured that online version of the page works properly.
- Updated the README to include a link to the online version.